### PR TITLE
Attempt to fix next href interpolation error

### DIFF
--- a/pages/new_doc.tsx
+++ b/pages/new_doc.tsx
@@ -1,12 +1,13 @@
-import { creators } from "@/data/fb"
 import { CircularProgress } from "@mui/material"
+import Router from "next/router"
 import { useEffect } from "react"
 import { v4 as uuidv4 } from "uuid"
 
 const GenNewDocView = () => {
   useEffect(() => {
     const uuid = uuidv4()
-    window.location.href = `/new_doc/${uuid}`
+    Router.push({ pathname: `/new_doc/${uuid}`, query: { docJobKey: uuid } })
+    // window.location.href = `/new_doc/${uuid}`
   }, [])
 
   return (


### PR DESCRIPTION
Error message referenced this doc
https://nextjs.org/docs/messages/href-interpolation-failed

Figured error came from redirect of /new_doc to /new_doc/[docJobKey]

Tried to use Router instead of setting window.location.href
Followed this format
https://nextjs.org/docs/api-reference/next/router#with-url-object
